### PR TITLE
DM-35470: Create a run-tox GitHub Action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'thursday'
+      time: '09:00'
+      timezone: America/Toronto

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,25 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+
+  pre-commit:
+    name: Lint with pre-commit
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install pre-commit
+        run: |
+          pip install --upgrade pre-commit
+          pre-commit install
+
+      - name: Run pre-commit
+        run: pre-commit run --all-files

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,13 @@
+name: Update Major Version Tag
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  update-majorver:
+    name: Update Major Version Tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: nowactions/update-majorver@v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: trailing-whitespace
+      - id: check-yaml
+
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.17.0
+    hooks:
+      - id: check-github-workflows
+      - id: check-dependabot
+      # Schema is not compatible with a composite action
+      # - id: check-github-actions

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: init
+init:
+	pip install --upgrade pip pre-commit
+	pre-commit install

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ jobs:
 
 - `python-version` (string, required) the Python version.
 - `tox-envs` (string, required) the tox environments to run, as a comma-delimited list. Example: `typing,py` to run a type checking environment and the Python environment.
-- `tox-requirements` (string, optional) Pip requirements for running tox. Default is `tox`, but you can also include tox plugins (e.g., `tox tox-docker`).
+- `tox-package` (string, optional) Pip requirement for tox itself (argument to `pip install`). Default is `tox`, but you can also include tox plugins (e.g., `tox tox-docker`).
+- `tox-plugins` (string, optional) Pip requirements for any tox plugins (arguments to `pip install`). Default is an empty string, but can be set to `tox-docker` to install Docker support, for example.
 - `tox-posargs` (string, optional) Command line arguments to pass to the tox command. The positional arguments are made available as the `{posargs}` substitution to tox environments. Default is an empty string.
 - `cache-key-prefix` (string, optional) Prefix for the tox environment cache key. Set to distinguish from other caches. Default is `tox`.
 
@@ -57,6 +58,48 @@ jobs:
 
 No outputs.
 
+## Usage tips
+
+### Docker support for tox
+
+[tox-docker](https://github.com/tox-dev/tox-docker) is a plugin that lets you run Docker containers during your tox environment runs.
+This is a great way for your tests to use services like Postgres or Redis.
+To make `tox-docker` available, specify it in the `tox-plugins` argument:
+
+```yaml
+name: Python CI
+
+"on":
+  push:
+    tags:
+      - "*"
+    branches:
+      - "main"
+  pull_request: {}
+
+jobs:
+
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python:
+          - "3.8"
+          - "3.9"
+          - "3.10"
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # full history for setuptools_scm
+
+      - name: Run tox
+        uses: lsst-sqre/run-tox@v1
+        with:
+          python-version: ${{ matrix.python }}
+          tox-envs: "typing,py"
+          tox-plugins: "tox-docker"
+```
 
 ## Developer guide
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,70 @@
 # run-tox
 
 This is a [composite GitHub Action](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action) for running CI tasks through [tox](https://tox.wiki/en/latest/index.html#).
+
+The action:
+
+1. Sets up Python
+2. Installs/updates pip along with tox and any other tox plugins such as tox-docker
+3. Caches the tox environment
+4. Runs tox with the environments you specify
+
+## Example usage
+
+```yaml
+name: Python CI
+
+"on":
+  push:
+    tags:
+      - "*"
+    branches:
+      - "main"
+  pull_request: {}
+
+jobs:
+
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python:
+          - "3.8"
+          - "3.9"
+          - "3.10"
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # full history for setuptools_scm
+
+      - name: Run tox
+        uses: lsst-sqre/run-tox@v1
+        with:
+          python-version: ${{ matrix.python }}
+          tox-envs: "typing,py"
+```
+
+## Inputs
+
+- `python-version` (string, required) the Python version.
+- `tox-envs` (string, required) the tox environments to run, as a comma-delimited list. Example: `typing,py` to run a type checking environment and the Python environment.
+- `tox-requirements` (string, optional) Pip requirements for running tox. Default is `tox`, but you can also include tox plugins (e.g., `tox tox-docker`).
+- `tox-posargs` (string, optional) Command line arguments to pass to the tox command. The positional arguments are made available as the `{posargs}` substitution to tox environments. Default is an empty string.
+- `cache-key-prefix` (string, optional) Prefix for the tox environment cache key. Set to distinguish from other caches. Default is `tox`.
+
+## Outputs
+
+No outputs.
+
+
+## Developer guide
+
+This repository provides a **composite** GitHub Action, a type of action that packages multiple regular actions into a single step.
+We do this to make the GitHub Actions workflows of all our software projects more consistent and easier to maintain.
+[You can learn more about composite actions in the GitHub documentation.](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action)
+
+Create new releases using the GitHub Releases UI and assign a tag with a [semantic version](https://semver.org), including a `v` prefix. Choose the semantic version based on compatibility for users of this workflow. If backwards compatibility is broken, bump the major version.
+
+When a release is made, a new major version tag (i.e. `v1`, `v2`) is also made or moved using [nowactions/update-majorver](https://github.com/marketplace/actions/update-major-version).
+We generally expect that most users will track these major version tags.

--- a/action.yaml
+++ b/action.yaml
@@ -9,10 +9,14 @@ inputs:
   tox-envs:
     description: "Tox environments to run (a comma-delimited list)"
     required: true
-  tox-requirements:
-    description: "Pip requirements for running tox (e.g. tox tox-docker)"
+  tox-package:
+    description: "Pip requirements for installing tox"
     required: false
     default: "tox"
+  tox-plugins:
+    description: "Pip requirements for installing tox plugins (e.g. tox-docker)"
+    required: false
+    default: ""
   cache-key-prefix:
     description: >
       Prefix for the tox environment cache key. Set to distinguish from
@@ -37,7 +41,7 @@ runs:
     - name: Python install
       run: |
         python -m pip install --upgrade pip
-        python -m pip install --upgrade setuptools ${{ inputs.tox-requirements }}
+        python -m pip install --upgrade setuptools ${{ inputs.tox-package }} ${{ inputs.tox-plugins }}
 
     - name: Cache tox environments
       id: cache-tox

--- a/action.yaml
+++ b/action.yaml
@@ -1,0 +1,52 @@
+name: "Build and publish to PyPI"
+description: >
+  This composite action runs tox, and includes setting up Python and caching
+  the tox environments.
+inputs:
+  python-version:
+    description: "Python version"
+    required: true
+  tox-envs:
+    description: "Tox environments to run (a comma-delimited list)"
+    required: true
+  tox-requirements:
+    description: "Pip requirements for running tox (e.g. tox tox-docker)"
+    required: false
+    default: "tox"
+  cache-key-prefix:
+    description: >
+      Prefix for the tox environment cache key. Set to distinguish from
+      other caches.
+    required: false
+    default: "tox"
+  tox-posargs:
+    description: >
+      Additional arguments to the tox command that are available to
+      environments as the "{posargs}" substitution.
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Python install
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade setuptools ${{ inputs.tox-requirements }}
+
+    - name: Cache tox environments
+      id: cache-tox
+      uses: actions/cache@v3
+      with:
+        path: .tox
+        # setup.cfg and pyproject.toml have versioning info that would
+        # impact the tox environment.
+        key: ${{ inputs.cache-key-prefix}}-${{ inputs.python-version }}-${{ hashFiles('pyproject.toml', 'setup.cfg') }}
+
+    - name: Run tox
+      run: tox -e ${{ inputs.tox-envs }} ${{ inputs.tox-posargs }}


### PR DESCRIPTION
This is a [composite GitHub Action](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action) for running CI tasks through [tox](https://tox.wiki/en/latest/index.html#). The algorithm is:

1. Sets up Python
2. Installs/updates pip along with tox and any other tox plugins such as tox-docker
3. Caches the tox environment
4. Run tox with the environments you specify

Implementing this as a composite action provides a lot of flexibility for our apps and packages, in that their workflows can specify job matrices, the tox environments that are run, and even what tox plugins to use.

Once thing about this action that differs from what we've been doing lately in our projects that is the `setup-python` action is not doing any dependency caching. `setup-python` needs a dependencies file to key against, however we're installing the latest tox always. Potentially a work-around would be to write the dependencies to a requirements file somewhere in the working directory? On the other hand, is caching `tox` important to performance? The action is caching the `.tox` directory, though.