### PR TITLE
DM-35491: Add use-cache input to make caching optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ jobs:
 - `tox-plugins` (string, optional) Pip requirements for any tox plugins (arguments to `pip install`). Default is an empty string, but can be set to `tox-docker` to install Docker support, for example.
 - `tox-posargs` (string, optional) Command line arguments to pass to the tox command. The positional arguments are made available as the `{posargs}` substitution to tox environments. Default is an empty string.
 - `cache-key-prefix` (string, optional) Prefix for the tox environment cache key. Set to distinguish from other caches. Default is `tox`.
+- `use-cache` (boolean, optional) Flag is enable caching of the tox environment. Default is `true`.
 
 ## Outputs
 

--- a/action.yaml
+++ b/action.yaml
@@ -17,18 +17,23 @@ inputs:
     description: "Pip requirements for installing tox plugins (e.g. tox-docker)"
     required: false
     default: ""
-  cache-key-prefix:
-    description: >
-      Prefix for the tox environment cache key. Set to distinguish from
-      other caches.
-    required: false
-    default: "tox"
   tox-posargs:
     description: >
       Additional arguments to the tox command that are available to
       environments as the "{posargs}" substitution.
     required: false
     default: ""
+  cache-key-prefix:
+    description: >
+      Prefix for the tox environment cache key. Set to distinguish from
+      other caches.
+    required: false
+    default: "tox"
+  use-cache:
+    description: >
+      Flag is enable caching of the tox environment
+    requierd: false
+    default: "true"
 
 runs:
   using: "composite"
@@ -46,6 +51,7 @@ runs:
     - name: Cache tox environments
       id: cache-tox
       uses: actions/cache@v3
+      if: fromJSON(${{ inputs.use-cache }})
       with:
         path: .tox
         # setup.cfg and pyproject.toml have versioning info that would


### PR DESCRIPTION
This enables run-tox to be used in workflows where dependency caching isn't desirable, like periodic test runs to ensure a library works with the latest versions of dependencies.

Note that composite actions don't have "native" support for non-string types for inputs. However, the
[fromJSON](https://docs.github.com/en/actions/learn-github-actions/expressions#fromjson) function should handle this.