### PR TITLE
DM-35548: shell attribute is required for run actions

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -44,6 +44,7 @@ runs:
         python-version: ${{ inputs.python-version }}
 
     - name: Python install
+      shell: bash
       run: |
         python -m pip install --upgrade pip
         python -m pip install --upgrade setuptools ${{ inputs.tox-package }} ${{ inputs.tox-plugins }}
@@ -59,4 +60,5 @@ runs:
         key: ${{ inputs.cache-key-prefix}}-${{ inputs.python-version }}-${{ hashFiles('pyproject.toml', 'setup.cfg') }}
 
     - name: Run tox
+      shell: bash
       run: tox -e ${{ inputs.tox-envs }} ${{ inputs.tox-posargs }}


### PR DESCRIPTION
The "shell" property seems to be required on "run" actions in a composite action.