### PR TITLE
DM-39050: Add working-directory input

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ name: Python CI
   pull_request: {}
 
 jobs:
-
   tests:
     runs-on: ubuntu-latest
     strategy:
@@ -54,6 +53,7 @@ jobs:
 - `tox-posargs` (string, optional) Command line arguments to pass to the tox command. The positional arguments are made available as the `{posargs}` substitution to tox environments. Default is an empty string.
 - `cache-key-prefix` (string, optional) Prefix for the tox environment cache key. Set to distinguish from other caches. Default is `tox`.
 - `use-cache` (boolean, optional) Flag is enable caching of the tox environment. Default is `true`.
+- `working-directory` (string, optional) Directory to run tox in. Default is the repository root.
 
 ## Outputs
 
@@ -79,7 +79,6 @@ name: Python CI
   pull_request: {}
 
 jobs:
-
   tests:
     runs-on: ubuntu-latest
     strategy:

--- a/action.yaml
+++ b/action.yaml
@@ -32,7 +32,7 @@ inputs:
   use-cache:
     description: >
       Flag is enable caching of the tox environment
-    requierd: false
+    required: false
     default: "true"
 
 runs:

--- a/action.yaml
+++ b/action.yaml
@@ -34,6 +34,11 @@ inputs:
       Flag is enable caching of the tox environment
     required: false
     default: "true"
+  working-directory:
+    description: >
+      Directory to run tox in
+    required: false
+    default: "."
 
 runs:
   using: "composite"
@@ -54,11 +59,12 @@ runs:
       uses: actions/cache@v3
       if: fromJSON(${{ inputs.use-cache }})
       with:
-        path: .tox
+        path: ${{ inputs.working-directory }}/.tox
         # setup.cfg and pyproject.toml have versioning info that would
         # impact the tox environment.
         key: ${{ inputs.cache-key-prefix}}-${{ inputs.python-version }}-${{ hashFiles('pyproject.toml', 'setup.cfg') }}
 
     - name: Run tox
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
       run: tox -e ${{ inputs.tox-envs }} ${{ inputs.tox-posargs }}

--- a/action.yaml
+++ b/action.yaml
@@ -1,4 +1,4 @@
-name: "Build and publish to PyPI"
+name: "Run tox"
 description: >
   This composite action runs tox, and includes setting up Python and caching
   the tox environments.


### PR DESCRIPTION
Adds a `working-directory` that allows you to run tox in a sub-directory of the repository. Useful for monorepos. The default is the root, `.`, which is the existing behaviour.