### PR TITLE
DM-39989: Separate posargs from the tox command

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install pre-commit
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
       - id: check-yaml
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.17.0
+    rev: 0.23.2
     hooks:
       - id: check-github-workflows
       - id: check-dependabot

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+Copyright (c) 2022-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/action.yaml
+++ b/action.yaml
@@ -67,4 +67,4 @@ runs:
     - name: Run tox
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      run: tox -e ${{ inputs.tox-envs }} ${{ inputs.tox-posargs }}
+      run: tox -e ${{ inputs.tox-envs }} -- ${{ inputs.tox-posargs }}

--- a/action.yaml
+++ b/action.yaml
@@ -67,4 +67,4 @@ runs:
     - name: Run tox
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      run: tox -e ${{ inputs.tox-envs }} -- ${{ inputs.tox-posargs }}
+      run: tox run -e ${{ inputs.tox-envs }} -- ${{ inputs.tox-posargs }}


### PR DESCRIPTION
tox v4 now requires that positional arguments to the underlying command be separated from the tox arguments with `--`. Add that marker before inputs.tox-posargs when invoking tox.