### PR TITLE
DM-40497: Set COLUMNS to 120 when running tox

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -68,3 +68,5 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: tox run -e ${{ inputs.tox-envs }} -- ${{ inputs.tox-posargs }}
+      env:
+        COLUMNS: 120


### PR DESCRIPTION
[pytest-pretty](https://github.com/samuelcolvin/pytest-pretty) uses rich to format the pytest output, which in turn honors COLUMNS to determine the width of the screen and defaults to 80 columns. In GitHub Actions, 120 columns works fine with the GitHub Action log UI and presents more information.

I considered making this an optional parameter, but I convinced myself that there was no drawback to always setting a wider "screen" than the default. Tests that are specific to certain screen widths should be overriding COLUMNS inside the test.