### PR TITLE
DM-46034: Fix implementation of use-cache

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -71,7 +71,7 @@ runs:
     - name: Cache tox environments
       id: cache-tox
       uses: actions/cache@v4
-      if: fromJSON(${{ inputs.use-cache }})
+      if: inputs.use-cache == 'true'
       with:
         path: ${{ inputs.working-directory }}/.tox
         # setup.cfg and pyproject.toml have versioning info that would

--- a/action.yaml
+++ b/action.yaml
@@ -71,7 +71,7 @@ runs:
     - name: Cache tox environments
       id: cache-tox
       uses: actions/cache@v4
-      if: inputs.use-cache == 'true'
+      if: fromJSON(inputs.use-cache) == true
       with:
         path: ${{ inputs.working-directory }}/.tox
         # setup.cfg and pyproject.toml have versioning info that would


### PR DESCRIPTION
The `fromJSON` trick to force a boolean argument to a boolean appears to not work based on GitHub Actions output for Gafaelfawr. Compare use-cache against a string 'true' instead, which is reported to work correctly.